### PR TITLE
Remove Expect: 100-Continue header by HttpClient and add Decompression for GZipped responses

### DIFF
--- a/authentication/Authentication_Cba/Sample.Authentication.Cba/Services/BaseService.cs
+++ b/authentication/Authentication_Cba/Sample.Authentication.Cba/Services/BaseService.cs
@@ -31,6 +31,7 @@ namespace Sample.Authentication.Cba.Services
             {
                 using (HttpClient httpClient = new HttpClient(new HttpClientHandler() { AllowAutoRedirect = false, UseCookies = false }))
                 {
+                    httpClient.DefaultRequestHeaders.ExpectContinue = false;
                     HttpResponseMessage res = httpClient.SendAsync(request).Result;
                     content = res.Content.ReadAsStringAsync().Result;
                     res.EnsureSuccessStatusCode();

--- a/authentication/Authentication_Cba/Sample.Authentication.Cba/Services/BaseService.cs
+++ b/authentication/Authentication_Cba/Sample.Authentication.Cba/Services/BaseService.cs
@@ -31,6 +31,11 @@ namespace Sample.Authentication.Cba.Services
             {
                 using (HttpClient httpClient = new HttpClient(new HttpClientHandler() { AllowAutoRedirect = false, UseCookies = false }))
                 {
+                    // Disable Expect: 100 Continue according to https://www.developer.saxo/openapi/learn/openapi-request-response
+                    // In our experience the same two-step process has been difficult to get to work reliable, especially as we support clients world wide, 
+                    // who connect to us through a multitude of network gateways and proxies.We also find that the actual bandwidth savings for the majority of API requests are limited, 
+                    // since most requests are quite small.
+                    // We therefore strongly recommend against using the Expect:100 - Continue header, and expect you to make sure your client library does not rely on this mechanism.
                     httpClient.DefaultRequestHeaders.ExpectContinue = false;
                     HttpResponseMessage res = httpClient.SendAsync(request).Result;
                     content = res.Content.ReadAsStringAsync().Result;

--- a/authentication/Authentication_CodeFlow/Sample.Authentication.Server/Services/BaseService.cs
+++ b/authentication/Authentication_CodeFlow/Sample.Authentication.Server/Services/BaseService.cs
@@ -35,6 +35,7 @@ namespace Sample.Authentication.Server.Services
             {
                 using (var httpClient = new HttpClient(new HttpClientHandler() { AllowAutoRedirect = false, UseCookies = false }))
                 {
+                    httpClient.DefaultRequestHeaders.ExpectContinue = false;
                     var res = httpClient.SendAsync(request).Result;
                     content = res.Content.ReadAsStringAsync().Result;
                     res.EnsureSuccessStatusCode();

--- a/authentication/Authentication_CodeFlow/Sample.Authentication.Server/Services/BaseService.cs
+++ b/authentication/Authentication_CodeFlow/Sample.Authentication.Server/Services/BaseService.cs
@@ -35,6 +35,11 @@ namespace Sample.Authentication.Server.Services
             {
                 using (var httpClient = new HttpClient(new HttpClientHandler() { AllowAutoRedirect = false, UseCookies = false }))
                 {
+                    // Disable Expect: 100 Continue according to https://www.developer.saxo/openapi/learn/openapi-request-response
+                    // In our experience the same two-step process has been difficult to get to work reliable, especially as we support clients world wide, 
+                    // who connect to us through a multitude of network gateways and proxies.We also find that the actual bandwidth savings for the majority of API requests are limited, 
+                    // since most requests are quite small.
+                    // We therefore strongly recommend against using the Expect:100 - Continue header, and expect you to make sure your client library does not rely on this mechanism.
                     httpClient.DefaultRequestHeaders.ExpectContinue = false;
                     var res = httpClient.SendAsync(request).Result;
                     content = res.Content.ReadAsStringAsync().Result;

--- a/authentication/Authentication_PKCE/Sample.Auth.Pkce/Services/BaseService.cs
+++ b/authentication/Authentication_PKCE/Sample.Auth.Pkce/Services/BaseService.cs
@@ -35,6 +35,7 @@ namespace Sample.Auth.Pkce.Services
             {
                 using (var httpClient = new HttpClient(new HttpClientHandler() { AllowAutoRedirect = false, UseCookies = false }))
                 {
+                    httpClient.DefaultRequestHeaders.ExpectContinue = false;
                     var res = httpClient.SendAsync(request).Result;
                     content = res.Content.ReadAsStringAsync().Result;
                     res.EnsureSuccessStatusCode();

--- a/authentication/Authentication_PKCE/Sample.Auth.Pkce/Services/BaseService.cs
+++ b/authentication/Authentication_PKCE/Sample.Auth.Pkce/Services/BaseService.cs
@@ -35,6 +35,11 @@ namespace Sample.Auth.Pkce.Services
             {
                 using (var httpClient = new HttpClient(new HttpClientHandler() { AllowAutoRedirect = false, UseCookies = false }))
                 {
+                    // Disable Expect: 100 Continue according to https://www.developer.saxo/openapi/learn/openapi-request-response
+                    // In our experience the same two-step process has been difficult to get to work reliable, especially as we support clients world wide, 
+                    // who connect to us through a multitude of network gateways and proxies.We also find that the actual bandwidth savings for the majority of API requests are limited, 
+                    // since most requests are quite small.
+                    // We therefore strongly recommend against using the Expect:100 - Continue header, and expect you to make sure your client library does not rely on this mechanism.
                     httpClient.DefaultRequestHeaders.ExpectContinue = false;
                     var res = httpClient.SendAsync(request).Result;
                     content = res.Content.ReadAsStringAsync().Result;

--- a/websockets/Streaming.WebSocket.Samples/Program.cs
+++ b/websockets/Streaming.WebSocket.Samples/Program.cs
@@ -66,12 +66,10 @@ namespace Streaming.WebSocket.Samples
 		/// </summary>
 		private static void ListenForEscape()
 		{
-			ConsoleKeyInfo key = new ConsoleKeyInfo();
-
-			while (!Console.KeyAvailable)
+            while (!Console.KeyAvailable)
 			{
-				key = Console.ReadKey(true);
-				if (key.Key == ConsoleKey.Escape)
+                ConsoleKeyInfo key = Console.ReadKey(true);
+                if (key.Key == ConsoleKey.Escape)
 				{
 					_closeConnectionAction?.Invoke();
 					break;

--- a/websockets/Streaming.WebSocket.Samples/Streaming.WebSocket.Samples.csproj
+++ b/websockets/Streaming.WebSocket.Samples/Streaming.WebSocket.Samples.csproj
@@ -34,8 +34,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/websockets/Streaming.WebSocket.Samples/Streaming.WebSocket.Samples.csproj
+++ b/websockets/Streaming.WebSocket.Samples/Streaming.WebSocket.Samples.csproj
@@ -37,8 +37,12 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="RestSharp, Version=106.11.7.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.11.7\lib\net452\RestSharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/websockets/Streaming.WebSocket.Samples/Streaming.WebSocket.Samples.csproj
+++ b/websockets/Streaming.WebSocket.Samples/Streaming.WebSocket.Samples.csproj
@@ -37,9 +37,6 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=106.11.7.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.106.11.7\lib\net452\RestSharp.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />

--- a/websockets/Streaming.WebSocket.Samples/WebSocketSample.cs
+++ b/websockets/Streaming.WebSocket.Samples/WebSocketSample.cs
@@ -149,6 +149,7 @@ namespace Streaming.WebSocket.Samples
 
 			//Start a task to renew the token when needed. If we don't do this the connection will be terminated once the token expires.
 			DateTime tokenDummyExpiryTime = DateTime.Now.AddHours(2); //Here you need to provide the correct expiry time for the token. This is just a dummy value.
+			//When the code breaks here, you probably need to add a valid _token in the code above.
 			Task taskReauthorization = new Task(async () => { await ReauthorizeWhenNeeded(tokenDummyExpiryTime, cts.Token); }, cts.Token);
 			taskReauthorization.Start();
 

--- a/websockets/Streaming.WebSocket.Samples/WebSocketSample.cs
+++ b/websockets/Streaming.WebSocket.Samples/WebSocketSample.cs
@@ -111,7 +111,7 @@ namespace Streaming.WebSocket.Samples
 		public WebSocketSample()
 		{
 			//A valid OAuth2 _token - get a 24-hour token here: https://www.developer.saxo/openapi/token/current
-            _token = "eyJhbGciOiJFUzI1NiIsIng1dCI6IjhGQzE5Qjc0MzFCNjNFNTVCNjc0M0QwQTc5MjMzNjZCREZGOEI4NTAifQ.eyJvYWEiOiI3Nzc3NSIsImlzcyI6Im9hIiwiYWlkIjoiMTA5IiwidWlkIjoiZFg4NzBzYTJkaXVVMWRjSTVlfGtjQT09IiwiY2lkIjoiZFg4NzBzYTJkaXVVMWRjSTVlfGtjQT09IiwiaXNhIjoiRmFsc2UiLCJ0aWQiOiIyMDAyIiwic2lkIjoiODk5OGI5ZDI3MzRjNGE0NmIxNjNkMGY3ZDNmY2M2MTciLCJkZ2kiOiI4NCIsImV4cCI6IjE2MjQ1MDE4OTIiLCJvYWwiOiIxRiJ9.wCwt59ErpN7LTwg3XfNqKvMjCDok5XtgNuAArNOQGjrcChAHulxhkPCNuD1uiqDgt3xAAY_NYnDI15Rtwgjlzw";
+            _token = "#######";
 
 			//Url for streaming server.
 			_webSocketConnectionUrl = "wss://streaming.saxobank.com/sim/openapi/streamingws/connect";

--- a/websockets/Streaming.WebSocket.Samples/WebSocketSample.cs
+++ b/websockets/Streaming.WebSocket.Samples/WebSocketSample.cs
@@ -204,6 +204,10 @@ namespace Streaming.WebSocket.Samples
 			using (HttpClient httpClient = new HttpClient())
 			{
 				// Disable Expect: 100 Continue according to https://www.developer.saxo/openapi/learn/openapi-request-response
+				// In our experience the same two-step process has been difficult to get to work reliable, especially as we support clients world wide, 
+				// who connect to us through a multitude of network gateways and proxies.We also find that the actual bandwidth savings for the majority of API requests are limited, 
+				// since most requests are quite small.
+				// We therefore strongly recommend against using the Expect:100 - Continue header, and expect you to make sure your client library does not rely on this mechanism.
 				httpClient.DefaultRequestHeaders.ExpectContinue = false;
 
 				Uri reauthorizationUrl = new Uri($"{_webSocketAuthorizationUrl}?contextid={_contextId}");
@@ -226,6 +230,10 @@ namespace Streaming.WebSocket.Samples
 			using (HttpClient httpClient = new HttpClient())
 			{
 				// Disable Expect: 100 Continue according to https://www.developer.saxo/openapi/learn/openapi-request-response
+				// In our experience the same two-step process has been difficult to get to work reliable, especially as we support clients world wide, 
+				// who connect to us through a multitude of network gateways and proxies.We also find that the actual bandwidth savings for the majority of API requests are limited, 
+				// since most requests are quite small.
+				// We therefore strongly recommend against using the Expect:100 - Continue header, and expect you to make sure your client library does not rely on this mechanism.
 				httpClient.DefaultRequestHeaders.ExpectContinue = false;
 
 				//In a real implementation we would look at the reference ids passed in and 
@@ -260,6 +268,10 @@ namespace Streaming.WebSocket.Samples
 			using (HttpClient httpClient = new HttpClient())
 			{
 				// Disable Expect: 100 Continue according to https://www.developer.saxo/openapi/learn/openapi-request-response
+				// In our experience the same two-step process has been difficult to get to work reliable, especially as we support clients world wide, 
+				// who connect to us through a multitude of network gateways and proxies.We also find that the actual bandwidth savings for the majority of API requests are limited, 
+				// since most requests are quite small.
+				// We therefore strongly recommend against using the Expect:100 - Continue header, and expect you to make sure your client library does not rely on this mechanism.
 				httpClient.DefaultRequestHeaders.ExpectContinue = false;
 				using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, _priceSubscriptionUrl))
 				{

--- a/websockets/Streaming.WebSocket.Samples/WebSocketSample.cs
+++ b/websockets/Streaming.WebSocket.Samples/WebSocketSample.cs
@@ -112,7 +112,7 @@ namespace Streaming.WebSocket.Samples
 		public WebSocketSample()
 		{
 			//A valid OAuth2 _token - get a 24-hour token here: https://www.developer.saxo/openapi/token/current
-			_token = "eyJhbGciOiJFUzI1NiIsIng1dCI6IjhGQzE5Qjc0MzFCNjNFNTVCNjc0M0QwQTc5MjMzNjZCREZGOEI4NTAifQ.eyJvYWEiOiI3Nzc3NSIsImlzcyI6Im9hIiwiYWlkIjoiMTA5IiwidWlkIjoiZFg4NzBzYTJkaXVVMWRjSTVlfGtjQT09IiwiY2lkIjoiZFg4NzBzYTJkaXVVMWRjSTVlfGtjQT09IiwiaXNhIjoiRmFsc2UiLCJ0aWQiOiIyMDAyIiwic2lkIjoiNmZiZWEyYjNkODgzNGNkZGIxMjlkMjQ3NDBkNmVlM2MiLCJkZ2kiOiI4NCIsImV4cCI6IjE2MjQ1MTgyNTQiLCJvYWwiOiIxRiJ9.Udoz8QV_2Jwpva_AbLPu3N8a8AdUt9Wxzq7NIs6UmYttky3y9_efNOwWI_SUQBdxPRdpo4WnOKPygAlQAnhODA";
+			_token = "######";
 
 			//Url for streaming server.
 			_webSocketConnectionUrl = "wss://streaming.saxobank.com/sim/openapi/streamingws/connect";

--- a/websockets/Streaming.WebSocket.Samples/packages.config
+++ b/websockets/Streaming.WebSocket.Samples/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
 </packages>

--- a/websockets/Streaming.WebSocket.Samples/packages.config
+++ b/websockets/Streaming.WebSocket.Samples/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
-  <package id="RestSharp" version="106.11.7" targetFramework="net461" />
 </packages>

--- a/websockets/Streaming.WebSocket.Samples/packages.config
+++ b/websockets/Streaming.WebSocket.Samples/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="RestSharp" version="106.11.7" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Hi Fred,

This pull is for removing the Expect: 100-Continue header in the requests. The root cause is the HttpClient in C# enables Expect: 100-Continue by default. So I have replaced it with the new RestClient to solve the problem.

Please review and merge. Free to add comments and I will change the  codes accordingly

/Ray.